### PR TITLE
Fix error displaying IDP_FLEX roster icons

### DIFF
--- a/src/lib/Rosters/RosterRow.svelte
+++ b/src/lib/Rosters/RosterRow.svelte
@@ -3,8 +3,8 @@
 	
 	export let player;
 
-	const playerSLotClass = player.slot.replace('/', '').replace('SUPER_', 'S-').replace('REC_', 'R-');
-	const playerSlot = player.slot.replace('SUPER_', 'S ').replace('REC_', 'R ');
+	const playerSLotClass = player.slot.replace('/', '').replace('SUPER_', 'S-').replace('REC_', 'R-').replace('IDP_FLEX','IDP');
+	const playerSlot = player.slot.replace('SUPER_', 'S ').replace('REC_', 'R ').replace('IDP_FLEX','IDP');
 </script>
 
 <style>


### PR DESCRIPTION
At present the IDP_FLEX position is not displaying properly (too wide and doesn't have any CSS styling) as the code assumes it will be 'IDP' rather than 'IDP_FLEX'. It is likely that at some point Sleeper updated their API and this code hadn't caught up.